### PR TITLE
feat: add deduplication for card requests

### DIFF
--- a/src/deduplication.ts
+++ b/src/deduplication.ts
@@ -1,0 +1,46 @@
+import { CacheOptions } from "./types/general";
+
+const pendingRenders = new Map<string, Promise<Uint8Array | null | undefined>>();
+
+/**
+ * Wrap a card rendering promise to deduplicate it.
+ * @param key The unique key for the card request.
+ * @param res The promise to wrap.
+ * @returns The deduplicated promise.
+ */
+export function dedupe(key: string, fn: () => Promise<Uint8Array | null | undefined>) {
+    const existing = pendingRenders.get(key);
+    console.log("existing?", !!existing);
+    if (existing) return existing;
+
+    // Use Promise.resolve to catch synchronous errors.
+    const res = Promise.resolve().then(fn);
+    pendingRenders.set(key, res);
+    res.finally(() => pendingRenders.delete(key));
+    return res;
+}
+
+/**
+ * Generate a unique key for a card request for deduplication.
+ * @param url The URL to get the card from.
+ * @param locale The locale to parse into Enka.
+ * @param cacheOptions The cache options.
+ * @param index The character index in the case of UID lookups
+ * @returns The unique key.
+ */
+export function makeCardKey(
+    url: string,
+    locale: string,
+    cache: CacheOptions,
+    index?: number,
+) {
+    return [
+        url,
+        locale,
+        index ?? "-",
+        cache.substats ? "1" : "0",
+        cache.subsBreakdown ? "1" : "0",
+        cache.uid ? "1" : "0",
+        cache.hideNames ? "1" : "0",
+    ].join("|");
+}

--- a/src/deduplication.ts
+++ b/src/deduplication.ts
@@ -10,7 +10,6 @@ const pendingRenders = new Map<string, Promise<Uint8Array | null | undefined>>()
  */
 export function dedupe(key: string, fn: () => Promise<Uint8Array | null | undefined>) {
     const existing = pendingRenders.get(key);
-    console.log("existing?", !!existing);
     if (existing) return existing;
 
     // Use Promise.resolve to catch synchronous errors.


### PR DESCRIPTION
Currently, when multiple requests go into an uncached route at the same time, it renders multiple times. This PR fixes that.

It uses a global `Map<string, Promise<Uint8Array | null | undefined>>` to store the first request’s pending promise. When another request comes in with the same key, it returns that promise instead of starting a new render.

This should improve speed and reduce rate limit usage for enka.cards.

I’ve only roughly tested this because of my slow wifi and limitations on development environment, but from what I can tell there shouldn’t be anything broken.