### PR TITLE
fix: properly handle private showcases

### DIFF
--- a/src/routes/genshin/uid.ts
+++ b/src/routes/genshin/uid.ts
@@ -21,6 +21,9 @@ export default (app: App) =>
 
                 const data = (await res.json()) as GenshinUid;
 
+                if (!data.avatarInfoList)
+                    return status(400, "Showcase is not public");
+
                 const characterIndex = data.avatarInfoList.findIndex(
                     (x) => x.avatarId === parseInt(characterId)
                 );

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -47,7 +47,7 @@ export interface BaseHoyoProfile {
 
 // Only avatarId is needed here, so this is just a basic implementation.
 export interface GenshinUid {
-    avatarInfoList: {
+    avatarInfoList?: {
         avatarId: number;
     }[]
 }


### PR DESCRIPTION
This pull request fixes the issue where accounts with no showcase gives no `avatarInfoList` instead of a blank array. This makes `findIndex` throws an error. I've added a check to return 400 early with proper error message.